### PR TITLE
feat: Create settings_service microservice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,3 +112,28 @@ services:
       postgres-db:
         condition: service_healthy
     restart: unless-stopped
+
+  settings_service:
+    build:
+      context: ./settings_service
+      dockerfile: Dockerfile
+    container_name: settings_service
+    ports:
+      - "3001:3000" # Different port than shop_service
+    volumes:
+      - ./settings_service:/usr/src/app
+      - /usr/src/app/node_modules
+    environment:
+      - NODE_ENV=development
+      # - PORT=3000 # Already exposed and set in service by default
+      - DB_HOST=postgres-db
+      - DB_USER=keycloakadmin # Assuming same DB user for now
+      - DB_PASSWORD=StrongPassword123! # Assuming same DB password
+      - DB_NAME=SettingsDb # Different database name
+      - DB_PORT=5432
+    networks:
+      - keycloak_network
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+    restart: unless-stopped

--- a/settings_service/.gitkeep
+++ b/settings_service/.gitkeep
@@ -1,0 +1,2 @@
+# This file is created to ensure the directory is added to git.
+# It can be removed later if other files are added to this directory.

--- a/settings_service/Dockerfile
+++ b/settings_service/Dockerfile
@@ -1,0 +1,33 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine AS builder
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (or yarn.lock)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build TypeScript code
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+# Copy built artifacts from builder stage
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY --from=builder /usr/src/app/package*.json ./
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Command to run the application
+CMD ["node", "dist/index.js"]

--- a/settings_service/README.md
+++ b/settings_service/README.md
@@ -1,0 +1,174 @@
+# Shop Service
+
+## Table of Contents
+
+- [About](#about)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+- [Running the Service](#running-the-service)
+  - [Development Mode](#development-mode)
+  - [Production Mode](#production-mode)
+  - [Docker](#docker)
+- [Scripts](#scripts)
+- [API Endpoints (Phase 1)](#api-endpoints-phase-1)
+- [Testing (Phase 1)](#testing-phase-1)
+- [Project Structure](#project-structure)
+- [Configuration (Phase 1)](#configuration-phase-1)
+
+## About
+
+This service will be responsible for handling shop-related functionalities. Currently, it's in its initial setup phase.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (v18.x or later recommended)
+- npm (usually comes with Node.js)
+- Docker (optional, for containerized deployment)
+- Access to a PostgreSQL database instance.
+
+### Installation
+
+1.  **Clone the repository (if not already done):**
+    ```bash
+    # Assuming you are in the root of the monorepo
+    cd shop_service
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+## Running the Service
+
+### Development Mode
+
+To run the service in development mode with hot-reloading (using nodemon):
+
+```bash
+npm run dev
+```
+
+The service will typically be available at `http://localhost:3000`.
+
+### Production Mode
+
+1.  **Build the TypeScript code:**
+    ```bash
+    npm run build
+    ```
+    This will compile the TypeScript files from `src/` into JavaScript files in the `dist/` directory.
+
+2.  **Start the service:**
+    ```bash
+    npm start
+    ```
+
+### Docker
+
+This service can also be run using Docker. Ensure Docker is installed and running.
+
+1.  **Using Docker Compose (recommended):**
+    The service is included in the main `docker-compose.yml` file at the root of the monorepo.
+    To start all services, including the shop_service:
+    ```bash
+    docker-compose up -d shop_service # Or `docker-compose up -d` for all
+    ```
+
+## Scripts
+
+The `package.json` file includes the following scripts:
+
+-   `npm start`: Starts the production server (after building).
+-   `npm run dev`: Starts the development server with nodemon.
+-   `npm run build`: Compiles TypeScript to JavaScript.
+-   `npm test`: Runs tests using Vitest.
+-   `npm run test:watch`: Runs tests in watch mode using Vitest.
+-   `npm run coverage`: Runs tests and generates a coverage report.
+
+## API Endpoints
+
+Currently, the service has the following basic endpoints:
+
+-   `GET /`: Returns a welcome message: "Shop Service is running! (Phase 1)"
+-   `GET /api/shop/info`: Returns shop information along with the current database time:
+    ```json
+    {
+      "message": "Shop information with current DB time",
+      "databaseTime": "YYYY-MM-DDTHH:mm:ss.sssZ"
+    }
+    ```
+
+## Testing
+
+Tests are written using [Vitest](https://vitest.dev/) and can be found in the `tests/` directory.
+
+-   To run all tests once:
+    ```bash
+    npm test
+    ```
+-   To run tests in watch mode:
+    ```bash
+    npm run test:watch
+    ```
+
+## Project Structure
+
+(A brief overview of the directory structure will be here - standard Express/TS layout)
+```
+shop_service/
+├── Dockerfile
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── README.md
+├── src/
+│   ├── app.ts
+│   ├── index.ts
+│   ├── server.ts
+│   ├── config/
+│   ├── controllers/
+│   ├── middlewares/
+│   ├── models/
+│   ├── routes/
+│   ├── services/
+│   ├── types/
+│   └── utils/
+└── tests/
+```
+
+## Configuration
+
+Service configuration is managed in `src/config/config.ts`. Environment variables are used for critical settings.
+
+### Environment Variables
+
+The following environment variables are used by the service:
+
+-   `NODE_ENV`: The runtime environment (e.g., `development`, `production`, `test`). Defaults to `development`.
+-   `PORT`: The port on which the service will listen. Defaults to `3000`.
+-   `DB_HOST`: Hostname of the PostgreSQL database server.
+-   `DB_PORT`: Port of the PostgreSQL database server. Defaults to `5432`.
+-   `DB_USER`: Username for connecting to the PostgreSQL database.
+-   `DB_PASSWORD`: Password for the specified database user.
+-   `DB_NAME`: The name of the PostgreSQL database to connect to (e.g., `ShopDb`).
+
+When running with Docker Compose (`docker-compose.yml` in the root), these database variables are pre-configured to connect to the `postgres-db` service.
+
+### Database Setup
+
+The service requires a PostgreSQL database named `ShopDb` (or as configured by `DB_NAME`).
+The user specified (`DB_USER`) must have permissions to connect to this database and perform standard operations.
+
+If the `ShopDb` database does not exist, it needs to be created manually or via an initialization script in the PostgreSQL service. The `keycloakadmin` user (used by default in docker-compose) typically has privileges to create databases. You can connect to the PostgreSQL instance (e.g., using Adminer on port 8082 or `psql` available in the `postgres-db` container) and execute:
+```sql
+CREATE DATABASE "ShopDb";
+```
+Ensure the `keycloakadmin` user has appropriate permissions on this new database, or grant them:
+```sql
+GRANT ALL PRIVILEGES ON DATABASE "ShopDb" TO keycloakadmin;
+```
+(Adjust grants as per security requirements; `ALL PRIVILEGES` is broad for development).

--- a/settings_service/migrations/001_create_settings_tables.sql
+++ b/settings_service/migrations/001_create_settings_tables.sql
@@ -1,0 +1,53 @@
+-- Migration to create products_vat and account_settings tables
+
+-- Drop tables if they exist (for easier re-running during development)
+DROP TABLE IF EXISTS products_vat CASCADE;
+DROP TABLE IF EXISTS account_settings CASCADE;
+
+-- Create products_vat table
+CREATE TABLE products_vat (
+    "productId" TEXT PRIMARY KEY,
+    ean TEXT NOT NULL,
+    "productName" TEXT NOT NULL,
+    "basePrice" DECIMAL,
+    "vatRate" DECIMAL NOT NULL,
+    "vatCategory" TEXT,
+    "countryCode" TEXT NOT NULL,
+    "isCompound" BOOLEAN DEFAULT FALSE,
+    "appliesToShipping" BOOLEAN DEFAULT FALSE,
+    "createdDateTime" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedDateTime" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isActive" BOOLEAN DEFAULT TRUE
+);
+
+-- Create account_settings table
+CREATE TABLE account_settings (
+    "accountId" TEXT PRIMARY KEY,
+    "accountName" TEXT NOT NULL,
+    "countryCode" TEXT NOT NULL,
+    "currencyCode" TEXT,
+    "defaultFulfilmentMethod" TEXT,
+    "vatRegistrationNumber" TEXT,
+    "createdDateTime" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedDateTime" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isActive" BOOLEAN DEFAULT TRUE
+);
+
+-- Optional: Add indexes for frequently queried columns
+CREATE INDEX IF NOT EXISTS idx_products_vat_ean ON products_vat(ean);
+CREATE INDEX IF NOT EXISTS idx_products_vat_country_code ON products_vat("countryCode");
+CREATE INDEX IF NOT EXISTS idx_account_settings_country_code ON account_settings("countryCode");
+
+COMMENT ON COLUMN products_vat."basePrice" IS 'Price excluding VAT';
+COMMENT ON COLUMN products_vat."vatRate" IS 'Percentage like 21.00 for 21% VAT';
+COMMENT ON COLUMN products_vat."vatCategory" IS 'e.g., ‘Standard’, ‘Reduced’, ‘Exempt’';
+COMMENT ON COLUMN products_vat."countryCode" IS 'e.g., ISO country code like ‘NL’ or ‘DE’ for VAT jurisdiction';
+COMMENT ON COLUMN products_vat."isCompound" IS 'Indicates if VAT is applied on top of other taxes';
+COMMENT ON COLUMN products_vat."appliesToShipping" IS 'Indicates if VAT applies to shipping costs';
+COMMENT ON COLUMN products_vat."isActive" IS 'Indicates if the product is available for sale';
+
+COMMENT ON COLUMN account_settings."countryCode" IS 'Links to products_vat.countryCode for tax settings';
+COMMENT ON COLUMN account_settings."currencyCode" IS 'e.g., ‘EUR’, ‘USD’, for pricing';
+COMMENT ON COLUMN account_settings."defaultFulfilmentMethod" IS 'e.g., ‘FBB’ or ‘FBA’';
+COMMENT ON COLUMN account_settings."vatRegistrationNumber" IS 'For VAT compliance';
+COMMENT ON COLUMN account_settings."isActive" IS 'Indicates if the account is active';

--- a/settings_service/package.json
+++ b/settings_service/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "settings_service",
+  "version": "1.0.0",
+  "description": "Settings service for the e-commerce platform",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "nodemon src/index.ts",
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "express",
+    "typescript",
+    "settings",
+    "vitest"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.10.7",
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.8",
+    "@types/supertest": "^2.0.12",
+    "c8": "^8.0.1",
+    "nodemon": "^3.0.1",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6",
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^0.34.6"
+  }
+}

--- a/settings_service/src/.gitkeep
+++ b/settings_service/src/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure src directory is tracked.

--- a/settings_service/src/app.ts
+++ b/settings_service/src/app.ts
@@ -1,0 +1,23 @@
+import express, { Application, Request, Response, NextFunction } from 'express';
+import mainRouter from './routes'; // Corrected from './routes/index' to './routes'
+import { errorHandler } from './middlewares/middlewares';
+import config from './config/config';
+
+const app: Application = express();
+
+// Middlewares
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Basic Route
+app.get('/', (req: Request, res: Response) => {
+  res.send('Settings Service is running! (Phase 1)');
+});
+
+// API Routes
+app.use('/api', mainRouter);
+
+// Error Handling Middleware - should be last middleware
+app.use(errorHandler);
+
+export default app;

--- a/settings_service/src/config/.gitkeep
+++ b/settings_service/src/config/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure config directory is tracked.

--- a/settings_service/src/config/config.ts
+++ b/settings_service/src/config/config.ts
@@ -1,0 +1,38 @@
+// This is a placeholder for configuration
+// Environment variables should be loaded here
+
+interface IDatabaseConfig {
+  host?: string;
+  port: number;
+  user?: string;
+  password?: string;
+  name?: string;
+}
+
+interface IConfig {
+  env: string;
+  port: number;
+  db: IDatabaseConfig;
+  // Add other configuration properties here
+}
+
+const config: IConfig = {
+  env: process.env.NODE_ENV || 'development',
+  port: parseInt(process.env.PORT || '3000', 10),
+  db: {
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT || '5432', 10),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    name: process.env.DB_NAME,
+  },
+};
+
+// Basic validation for essential DB config
+if (config.env !== 'test' && (!config.db.host || !config.db.user || !config.db.password || !config.db.name)) {
+  console.warn(
+    'Warning: One or more database configuration variables (DB_HOST, DB_USER, DB_PASSWORD, DB_NAME) are not set. Database connection might fail.'
+  );
+}
+
+export default config;

--- a/settings_service/src/controllers/.gitkeep
+++ b/settings_service/src/controllers/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure controllers directory is tracked.

--- a/settings_service/src/controllers/controllers.ts
+++ b/settings_service/src/controllers/controllers.ts
@@ -1,0 +1,6 @@
+// This is a placeholder for controller files naming convention
+// Each resource should have its own controller file, e.g., shop.controller.ts
+
+export const placeholderController = (message: string): void => {
+  console.log(`Placeholder controller function called with message: ${message}`);
+};

--- a/settings_service/src/controllers/settings.controller.ts
+++ b/settings_service/src/controllers/settings.controller.ts
@@ -1,0 +1,166 @@
+import { Request, Response, NextFunction } from 'express';
+import * as SettingsService from '../services/settings.service';
+import { IProductVat, IAccountSetting } from '../models/settings.model';
+
+// --- Controller functions for ProductsVat CRUD ---
+
+export const createProductVatHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const productVatData: IProductVat = req.body;
+    // Basic validation (more can be added with a library like Joi or Zod)
+    if (!productVatData.productId || !productVatData.ean || !productVatData.productName || productVatData.vatRate === undefined || !productVatData.countryCode) {
+      res.status(400).json({ message: 'Missing required fields: productId, ean, productName, vatRate, countryCode' });
+      return;
+    }
+    const newProductVat = await SettingsService.createProductVat(productVatData);
+    res.status(201).json(newProductVat);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getProductVatByIdHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { productId } = req.params;
+    const productVat = await SettingsService.getProductVatById(productId);
+    if (productVat) {
+      res.status(200).json(productVat);
+    } else {
+      res.status(404).json({ message: `Product VAT with ID ${productId} not found` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAllProductsVatHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const productsVat = await SettingsService.getAllProductsVat();
+    res.status(200).json(productsVat);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateProductVatHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { productId } = req.params;
+    const updateData: Partial<IProductVat> = req.body;
+
+    if (Object.keys(updateData).length === 0) {
+        res.status(400).json({ message: 'No update data provided.' });
+        return;
+    }
+    // Prevent primary key from being changed in body if passed
+    if (updateData.productId && updateData.productId !== productId) {
+        res.status(400).json({ message: 'Product ID in body does not match ID in path and cannot be changed.' });
+        return;
+    }
+    delete updateData.productId; // Ensure it's not part of the update payload sent to service
+
+    const updatedProductVat = await SettingsService.updateProductVat(productId, updateData);
+    if (updatedProductVat) {
+      res.status(200).json(updatedProductVat);
+    } else {
+      res.status(404).json({ message: `Product VAT with ID ${productId} not found or no changes made.` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteProductVatHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { productId } = req.params;
+    const success = await SettingsService.deleteProductVat(productId);
+    if (success) {
+      res.status(200).json({ message: `Product VAT with ID ${productId} deleted successfully` });
+      // Alt: res.status(204).send();
+    } else {
+      res.status(404).json({ message: `Product VAT with ID ${productId} not found or could not be deleted` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
+// --- Controller functions for AccountSettings CRUD ---
+
+export const createAccountSettingHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const accountSettingData: IAccountSetting = req.body;
+    // Basic validation
+    if (!accountSettingData.accountId || !accountSettingData.accountName || !accountSettingData.countryCode) {
+      res.status(400).json({ message: 'Missing required fields: accountId, accountName, countryCode' });
+      return;
+    }
+    const newAccountSetting = await SettingsService.createAccountSetting(accountSettingData);
+    res.status(201).json(newAccountSetting);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAccountSettingByIdHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { accountId } = req.params;
+    const accountSetting = await SettingsService.getAccountSettingById(accountId);
+    if (accountSetting) {
+      res.status(200).json(accountSetting);
+    } else {
+      res.status(404).json({ message: `Account Setting with ID ${accountId} not found` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAllAccountSettingsHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const accountSettings = await SettingsService.getAllAccountSettings();
+    res.status(200).json(accountSettings);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateAccountSettingHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { accountId } = req.params;
+    const updateData: Partial<IAccountSetting> = req.body;
+
+    if (Object.keys(updateData).length === 0) {
+        res.status(400).json({ message: 'No update data provided.' });
+        return;
+    }
+    if (updateData.accountId && updateData.accountId !== accountId) {
+        res.status(400).json({ message: 'Account ID in body does not match ID in path and cannot be changed.' });
+        return;
+    }
+    delete updateData.accountId;
+
+    const updatedAccountSetting = await SettingsService.updateAccountSetting(accountId, updateData);
+    if (updatedAccountSetting) {
+      res.status(200).json(updatedAccountSetting);
+    } else {
+      res.status(404).json({ message: `Account Setting with ID ${accountId} not found or no changes made.` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteAccountSettingHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { accountId } = req.params;
+    const success = await SettingsService.deleteAccountSetting(accountId);
+    if (success) {
+      res.status(200).json({ message: `Account Setting with ID ${accountId} deleted successfully` });
+      // Alt: res.status(204).send();
+    } else {
+      res.status(404).json({ message: `Account Setting with ID ${accountId} not found or could not be deleted` });
+    }
+  } catch (error) {
+    next(error);
+  }
+};

--- a/settings_service/src/index.ts
+++ b/settings_service/src/index.ts
@@ -1,0 +1,4 @@
+// Entry point for Phase 1
+import './server'; // This will import and run server.ts
+
+console.log('Settings Service application starting (Phase 1)...');

--- a/settings_service/src/middlewares/.gitkeep
+++ b/settings_service/src/middlewares/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure middlewares directory is tracked.

--- a/settings_service/src/middlewares/middlewares.ts
+++ b/settings_service/src/middlewares/middlewares.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const exampleMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  console.log('Example middleware executed');
+  next();
+};
+
+export const errorHandler = (err: Error, req: Request, res: Response, next: NextFunction): void => {
+    console.error(`Error: ${err.message}`, { stack: err.stack });
+    const statusCode = res.statusCode === 200 ? 500 : res.statusCode;
+    res.status(statusCode).json({
+        message: err.message || 'An unexpected error occurred.',
+        // stack: process.env.NODE_ENV === 'production' ? undefined : err.stack,
+    });
+};

--- a/settings_service/src/models/.gitkeep
+++ b/settings_service/src/models/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure models directory is tracked.

--- a/settings_service/src/models/models.ts
+++ b/settings_service/src/models/models.ts
@@ -1,0 +1,10 @@
+// This is a placeholder for model definitions naming convention
+
+export interface IPlaceholderModel {
+  id: string;
+  name: string;
+}
+
+export const placeholderModelFunction = (data: IPlaceholderModel): void => {
+  console.log('Placeholder model function called with data:', data);
+};

--- a/settings_service/src/models/settings.model.ts
+++ b/settings_service/src/models/settings.model.ts
@@ -1,0 +1,28 @@
+// Defines the TypeScript interfaces for the settings_service data models.
+
+export interface IProductVat {
+  productId: string; // primary key
+  ean: string; // not null
+  productName: string; // not null
+  basePrice?: number | null; // decimal
+  vatRate: number; // decimal, not null
+  vatCategory?: string | null;
+  countryCode: string; // not null, e.g., ISO country code
+  isCompound?: boolean | null;
+  appliesToShipping?: boolean | null;
+  createdDateTime: Date;
+  updatedDateTime: Date;
+  isActive?: boolean | null;
+}
+
+export interface IAccountSetting {
+  accountId: string; // primary key
+  accountName: string; // not null
+  countryCode: string; // not null, links to products_vat.countryCode
+  currencyCode?: string | null; // e.g., ‘EUR’, ‘USD’
+  defaultFulfilmentMethod?: string | null; // e.g., ‘FBB’ or ‘FBA’
+  vatRegistrationNumber?: string | null;
+  createdDateTime: Date;
+  updatedDateTime: Date;
+  isActive?: boolean | null;
+}

--- a/settings_service/src/routes/.gitkeep
+++ b/settings_service/src/routes/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure routes directory is tracked.

--- a/settings_service/src/routes/index.ts
+++ b/settings_service/src/routes/index.ts
@@ -1,0 +1,9 @@
+// Main router file for Phase 1 (renamed from routes.ts for convention)
+import { Router } from 'express';
+import settingsRoutes from './settings.routes';
+
+const router = Router();
+
+router.use('/settings', settingsRoutes);
+
+export default router;

--- a/settings_service/src/routes/settings.routes.ts
+++ b/settings_service/src/routes/settings.routes.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import {
+    createProductVatHandler,
+    getProductVatByIdHandler,
+    getAllProductsVatHandler,
+    updateProductVatHandler,
+    deleteProductVatHandler,
+    createAccountSettingHandler,
+    getAccountSettingByIdHandler,
+    getAllAccountSettingsHandler,
+    updateAccountSettingHandler,
+    deleteAccountSettingHandler
+} from '../controllers/settings.controller';
+
+const router = Router();
+
+// --- Routes for ProductsVat CRUD ---
+router.post('/products-vat', createProductVatHandler);
+router.get('/products-vat', getAllProductsVatHandler);
+router.get('/products-vat/:productId', getProductVatByIdHandler);
+router.put('/products-vat/:productId', updateProductVatHandler);
+router.delete('/products-vat/:productId', deleteProductVatHandler);
+
+// --- Routes for AccountSettings CRUD ---
+router.post('/account-settings', createAccountSettingHandler);
+router.get('/account-settings', getAllAccountSettingsHandler);
+router.get('/account-settings/:accountId', getAccountSettingByIdHandler);
+router.put('/account-settings/:accountId', updateAccountSettingHandler);
+router.delete('/account-settings/:accountId', deleteAccountSettingHandler);
+
+export default router;

--- a/settings_service/src/server.ts
+++ b/settings_service/src/server.ts
@@ -1,0 +1,100 @@
+import app from './app';
+import config from './config/config';
+import { testDBConnection, endDBPool, getDBPool, runMigrations } from './utils/db'; // Added runMigrations
+import http from 'http'; // Import http module
+
+let serverInstance: http.Server;
+
+async function startServer() {
+  console.log('Initializing database pool...');
+  getDBPool(); // Ensures pool is created using settings from config
+
+  console.log('Testing database connection...');
+  const dbConnected = await testDBConnection();
+
+  if (!dbConnected && config.env !== 'test') {
+    console.error('FATAL: Database connection failed. Migrations will not run and server may be unstable.');
+    // For critical DB dependency, uncomment next line to prevent server start:
+    // process.exit(1);
+  } else if (dbConnected) {
+    console.log('Database connection successful.');
+    // Run migrations after successful DB connection
+    try {
+      console.log('Running database migrations...');
+      await runMigrations();
+      console.log('Database migrations completed successfully.');
+    } catch (migrationError) {
+      console.error('FATAL: Database migrations failed. Server will not start.', migrationError);
+      process.exit(1); // Exit if migrations fail
+    }
+  } else if (!dbConnected && config.env === 'test') {
+    console.warn('Database connection failed in TEST environment. Skipping migrations. Continuing server start for tests that might not need DB.');
+  }
+
+
+  serverInstance = app.listen(config.port, () => {
+    console.log(`Server is running on port ${config.port} in ${config.env} mode`);
+  });
+
+  serverInstance.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.syscall !== 'listen') {
+      throw error;
+    }
+    console.error(`Failed to start server on port ${config.port}: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+async function shutdown(signal: string) {
+  console.log(`${signal} received. Shutting down gracefully...`);
+  if (serverInstance) {
+    serverInstance.close(async (err) => {
+      if (err) {
+        console.error('Error during HTTP server closing:', err);
+      } else {
+        console.log('HTTP server closed.');
+      }
+
+      await endDBPool(); // Ensure DB pool is closed
+
+      if (err) {
+        process.exit(1); // Exit with error if server close failed
+      } else {
+        process.exit(0); // Exit cleanly
+      }
+    });
+  } else {
+    // If serverInstance is not defined, just try to close DB pool
+    console.log('HTTP server was not running or already closed.');
+    await endDBPool();
+    process.exit(0);
+  }
+}
+
+// Handle common termination signals
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT')); // Ctrl+C
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  // Consider a more robust strategy for production, e.g., graceful shutdown
+  // shutdown('unhandledRejection'); // Potentially too aggressive
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception:', err);
+  // Trigger graceful shutdown for uncaught exceptions
+  shutdown('uncaughtException');
+});
+
+startServer().catch(error => {
+    console.error("Critical error during server startup:", error);
+    process.exit(1);
+});
+
+// Exporting app for supertest and serverInstance for direct control (e.g. closing in tests)
+export { app, serverInstance };
+// Note: For tests that import 'server' as default, they will need to be updated
+// to use named import 'serverInstance' or manage server lifecycle via 'app'.
+// The Phase 1 test file was `import server from '../src/server';`
+// This will break. Test file update is in a later step.

--- a/settings_service/src/services/.gitkeep
+++ b/settings_service/src/services/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure services directory is tracked.

--- a/settings_service/src/services/services.ts
+++ b/settings_service/src/services/services.ts
@@ -1,0 +1,6 @@
+// This is a placeholder for service files naming convention
+
+export const placeholderService = async (input: string): Promise<string> => {
+  console.log(`Placeholder service function called with input: ${input}`);
+  return `Processed: ${input}`;
+};

--- a/settings_service/src/services/settings.service.ts
+++ b/settings_service/src/services/settings.service.ts
@@ -1,0 +1,224 @@
+import { getDBPool } from '../utils/db';
+import { IProductVat, IAccountSetting } from '../models/settings.model.ts';
+
+// --- Service functions for ProductsVat CRUD ---
+
+export async function createProductVat(productVatData: IProductVat): Promise<IProductVat> {
+  const pool = getDBPool();
+  const {
+    productId,
+    ean,
+    productName,
+    basePrice = null,
+    vatRate,
+    vatCategory = null,
+    countryCode,
+    isCompound = false,
+    appliesToShipping = false,
+    createdDateTime = new Date(), // Will be overridden by DB default if column has it
+    updatedDateTime = new Date(), // Will be overridden by DB default if column has it
+    isActive = true,
+  } = productVatData;
+
+  // Ensure createdDateTime and updatedDateTime are valid Date objects or will be handled by DB
+  const pCreatedDateTime = createdDateTime instanceof Date ? createdDateTime : new Date();
+  const pUpdatedDateTime = updatedDateTime instanceof Date ? updatedDateTime : new Date();
+
+  const query = `
+    INSERT INTO products_vat (
+      "productId", ean, "productName", "basePrice", "vatRate", "vatCategory",
+      "countryCode", "isCompound", "appliesToShipping", "createdDateTime",
+      "updatedDateTime", "isActive"
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    RETURNING *;
+  `;
+  const values = [
+    productId, ean, productName, basePrice, vatRate, vatCategory,
+    countryCode, isCompound, appliesToShipping, pCreatedDateTime,
+    pUpdatedDateTime, isActive
+  ];
+
+  try {
+    const result = await pool.query(query, values);
+    return result.rows[0];
+  } catch (error) {
+    console.error('Error creating product VAT:', error);
+    throw error;
+  }
+}
+
+export async function getProductVatById(productId: string): Promise<IProductVat | null> {
+  const pool = getDBPool();
+  const query = 'SELECT * FROM products_vat WHERE "productId" = $1;';
+  try {
+    const result = await pool.query(query, [productId]);
+    return result.rows.length > 0 ? result.rows[0] : null;
+  } catch (error) {
+    console.error(`Error fetching product VAT by ID ${productId}:`, error);
+    throw error;
+  }
+}
+
+export async function getAllProductsVat(): Promise<IProductVat[]> {
+  const pool = getDBPool();
+  const query = 'SELECT * FROM products_vat ORDER BY "productName";';
+  try {
+    const result = await pool.query(query);
+    return result.rows;
+  } catch (error) {
+    console.error('Error fetching all products VAT:', error);
+    throw error;
+  }
+}
+
+export async function updateProductVat(productId: string, updateData: Partial<IProductVat>): Promise<IProductVat | null> {
+  const pool = getDBPool();
+  const setClauses: string[] = [];
+  const values: any[] = [];
+  let valueCount = 1;
+
+  // Always update updatedDateTime
+  updateData.updatedDateTime = new Date();
+
+  for (const [key, value] of Object.entries(updateData)) {
+    if (value !== undefined && key !== 'productId' && key !== 'createdDateTime') {
+        setClauses.push(`"${key}" = $${valueCount++}`);
+        values.push(value);
+    }
+  }
+
+  if (setClauses.length === 0) return getProductVatById(productId); // No actual fields to update
+  values.push(productId);
+
+  const query = `
+    UPDATE products_vat SET ${setClauses.join(', ')}
+    WHERE "productId" = $${valueCount} RETURNING *;`;
+  try {
+    const result = await pool.query(query, values);
+    return result.rows.length > 0 ? result.rows[0] : null;
+  } catch (error) {
+    console.error(`Error updating product VAT ID ${productId}:`, error);
+    throw error;
+  }
+}
+
+export async function deleteProductVat(productId: string): Promise<boolean> {
+  const pool = getDBPool();
+  const query = 'DELETE FROM products_vat WHERE "productId" = $1;';
+  try {
+    const result = await pool.query(query, [productId]);
+    return result.rowCount !== null && result.rowCount > 0;
+  } catch (error) {
+    console.error(`Error deleting product VAT ID ${productId}:`, error);
+    throw error;
+  }
+}
+
+// --- Service functions for AccountSettings CRUD ---
+
+export async function createAccountSetting(accountSettingData: IAccountSetting): Promise<IAccountSetting> {
+  const pool = getDBPool();
+  const {
+    accountId,
+    accountName,
+    countryCode,
+    currencyCode = null,
+    defaultFulfilmentMethod = null,
+    vatRegistrationNumber = null,
+    createdDateTime = new Date(), // Will be overridden by DB default
+    updatedDateTime = new Date(), // Will be overridden by DB default
+    isActive = true,
+  } = accountSettingData;
+
+  const pCreatedDateTime = createdDateTime instanceof Date ? createdDateTime : new Date();
+  const pUpdatedDateTime = updatedDateTime instanceof Date ? updatedDateTime : new Date();
+
+  const query = `
+    INSERT INTO account_settings (
+      "accountId", "accountName", "countryCode", "currencyCode",
+      "defaultFulfilmentMethod", "vatRegistrationNumber", "createdDateTime",
+      "updatedDateTime", "isActive"
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    RETURNING *;
+  `;
+  const values = [
+    accountId, accountName, countryCode, currencyCode,
+    defaultFulfilmentMethod, vatRegistrationNumber, pCreatedDateTime,
+    pUpdatedDateTime, isActive
+  ];
+
+  try {
+    const result = await pool.query(query, values);
+    return result.rows[0];
+  } catch (error) {
+    console.error('Error creating account setting:', error);
+    throw error;
+  }
+}
+
+export async function getAccountSettingById(accountId: string): Promise<IAccountSetting | null> {
+  const pool = getDBPool();
+  const query = 'SELECT * FROM account_settings WHERE "accountId" = $1;';
+  try {
+    const result = await pool.query(query, [accountId]);
+    return result.rows.length > 0 ? result.rows[0] : null;
+  } catch (error) {
+    console.error(`Error fetching account setting by ID ${accountId}:`, error);
+    throw error;
+  }
+}
+
+export async function getAllAccountSettings(): Promise<IAccountSetting[]> {
+  const pool = getDBPool();
+  const query = 'SELECT * FROM account_settings ORDER BY "accountName";';
+  try {
+    const result = await pool.query(query);
+    return result.rows;
+  } catch (error) {
+    console.error('Error fetching all account settings:', error);
+    throw error;
+  }
+}
+
+export async function updateAccountSetting(accountId: string, updateData: Partial<IAccountSetting>): Promise<IAccountSetting | null> {
+  const pool = getDBPool();
+  const setClauses: string[] = [];
+  const values: any[] = [];
+  let valueCount = 1;
+
+  // Always update updatedDateTime
+  updateData.updatedDateTime = new Date();
+
+  for (const [key, value] of Object.entries(updateData)) {
+    if (value !== undefined && key !== 'accountId' && key !== 'createdDateTime') {
+        setClauses.push(`"${key}" = $${valueCount++}`);
+        values.push(value);
+    }
+  }
+
+  if (setClauses.length === 0) return getAccountSettingById(accountId);
+  values.push(accountId);
+
+  const query = `
+    UPDATE account_settings SET ${setClauses.join(', ')}
+    WHERE "accountId" = $${valueCount} RETURNING *;`;
+  try {
+    const result = await pool.query(query, values);
+    return result.rows.length > 0 ? result.rows[0] : null;
+  } catch (error) {
+    console.error(`Error updating account setting ID ${accountId}:`, error);
+    throw error;
+  }
+}
+
+export async function deleteAccountSetting(accountId: string): Promise<boolean> {
+  const pool = getDBPool();
+  const query = 'DELETE FROM account_settings WHERE "accountId" = $1;';
+  try {
+    const result = await pool.query(query, [accountId]);
+    return result.rowCount !== null && result.rowCount > 0;
+  } catch (error) {
+    console.error(`Error deleting account setting ID ${accountId}:`, error);
+    throw error;
+  }
+}

--- a/settings_service/src/types/.gitkeep
+++ b/settings_service/src/types/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure types directory is tracked.

--- a/settings_service/src/types/types.ts
+++ b/settings_service/src/types/types.ts
@@ -1,0 +1,9 @@
+// This is a placeholder for custom TypeScript type definitions (Phase 1)
+
+export type UserId = string | number;
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}

--- a/settings_service/src/utils/.gitkeep
+++ b/settings_service/src/utils/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure utils directory is tracked.

--- a/settings_service/src/utils/db.ts
+++ b/settings_service/src/utils/db.ts
@@ -1,0 +1,151 @@
+import { Pool, PoolConfig } from 'pg';
+import config from '../config/config';
+
+let pool: Pool | null = null;
+
+const dbConfig: PoolConfig = {
+  user: config.db.user,
+  host: config.db.host,
+  database: config.db.name,
+  password: config.db.password,
+  port: config.db.port,
+  ssl: config.env === 'production' ? { rejectUnauthorized: false } : false,
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: config.env === 'test' ? 1000 : 5000, // Shorter timeout for tests
+};
+
+export const getDBPool = (): Pool => {
+  if (!pool) {
+    if (!config.db.host || !config.db.user || !config.db.password || !config.db.name) {
+        const errorMessage = 'Database configuration is incomplete. Cannot create connection pool.';
+        console.error(`FATAL ERROR: ${errorMessage} Check DB_HOST, DB_USER, DB_PASSWORD, DB_NAME.`);
+        throw new Error(errorMessage);
+    }
+    pool = new Pool(dbConfig);
+
+    pool.on('connect', (client) => {
+      console.log(`Database pool: client connected. Pool totalCount: ${pool?.totalCount}, idleCount: ${pool?.idleCount}, waitingCount: ${pool?.waitingCount}`);
+    });
+
+    pool.on('error', (err, client) => {
+      console.error('Unexpected error on idle client in database pool', err);
+    });
+
+    // Graceful shutdown for the pool (e.g. when app terminates)
+    // This is more robustly handled in server.ts shutdown hooks now.
+    // process.on('SIGINT', () => endDBPool().finally(() => process.exit(0)));
+    // process.on('SIGTERM', () => endDBPool().finally(() => process.exit(0)));
+  }
+  return pool;
+};
+
+export const testDBConnection = async (): Promise<boolean> => {
+  const currentPool = getDBPool(); // Ensures pool is initialized
+  let client;
+  try {
+    client = await currentPool.connect();
+    console.log('Successfully connected to the database via pool client.');
+    const res = await client.query('SELECT NOW()');
+    console.log('PostgreSQL current time from pool client:', res.rows[0].now);
+    return true;
+  } catch (error) {
+    console.error('Failed to connect to the database or query failed:', error);
+    if (error instanceof Error) {
+        if (error.message.includes('database') && error.message.includes('does not exist')) {
+            console.warn(`Attempted to connect to database "${config.db.name}", but it does not exist. Please ensure it is created.`);
+        } else if (error.message.includes('password authentication failed')) {
+            console.warn(`Password authentication failed for user "${config.db.user}". Please check credentials.`);
+        }
+    }
+    return false;
+  } finally {
+    if (client) {
+      client.release();
+      console.log('Database client released.');
+    }
+  }
+};
+
+export const endDBPool = async (): Promise<void> => {
+    if (pool) {
+        console.log('Attempting to close database pool...');
+        try {
+            await pool.end();
+            console.log('Database pool has been closed successfully.');
+            pool = null; // Reset pool variable
+        } catch (error) {
+            console.error('Error closing database pool:', error);
+        }
+    } else {
+        console.log('Database pool was not initialized or already closed.');
+    }
+};
+
+// New Migration Runner Logic
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../migrations');
+
+export const runMigrations = async (): Promise<void> => {
+  const currentPool = getDBPool(); // Ensures pool is initialized
+  let client;
+  try {
+    client = await currentPool.connect();
+    console.log('Connected to DB for running migrations.');
+
+    // Create migrations table if it doesn't exist
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version VARCHAR(255) PRIMARY KEY,
+        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    console.log('Checked/created schema_migrations table.');
+
+    const migrationFiles = (await fs.readdir(MIGRATIONS_DIR))
+      .filter(file => file.endsWith('.sql'))
+      .sort();
+
+    if (migrationFiles.length === 0) {
+      console.log('No migration files found.');
+      return;
+    }
+
+    console.log(`Found migration files: ${migrationFiles.join(', ')}`);
+
+    for (const file of migrationFiles) {
+      const version = file.split('_')[0]; // Assumes naming like 001_create_tables.sql
+      const filePath = path.join(MIGRATIONS_DIR, file);
+
+      const res = await client.query('SELECT version FROM schema_migrations WHERE version = $1', [version]);
+      if (res.rowCount === 0) {
+        console.log(`Running migration: ${file}`);
+        const sql = await fs.readFile(filePath, 'utf-8');
+        await client.query('BEGIN'); // Start transaction
+        try {
+          await client.query(sql);
+          await client.query('INSERT INTO schema_migrations (version) VALUES ($1)', [version]);
+          await client.query('COMMIT'); // Commit transaction
+          console.log(`Successfully applied migration: ${file}`);
+        } catch (migrationError) {
+          await client.query('ROLLBACK'); // Rollback transaction on error
+          console.error(`Error running migration ${file}:`, migrationError);
+          throw migrationError; // Propagate error to stop further migrations
+        }
+      } else {
+        console.log(`Migration ${file} (version ${version}) already applied.`);
+      }
+    }
+    console.log('All migrations processed.');
+  } catch (error) {
+    console.error('Migration process failed:', error);
+    throw error; // Re-throw to indicate failure
+  } finally {
+    if (client) {
+      client.release();
+      console.log('Migration DB client released.');
+    }
+  }
+};

--- a/settings_service/src/utils/utils.ts
+++ b/settings_service/src/utils/utils.ts
@@ -1,0 +1,10 @@
+// This is a placeholder for utility functions (Phase 1)
+
+export const generateRandomString = (length: number): string => {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+};

--- a/settings_service/tests/.gitkeep
+++ b/settings_service/tests/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure tests directory is tracked.

--- a/settings_service/tests/settings.test.ts
+++ b/settings_service/tests/settings.test.ts
@@ -1,0 +1,297 @@
+import request from 'supertest';
+import { Server } from 'http';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+
+import { app, serverInstance as actualServerInstanceImport } from '../src/server';
+import { endDBPool, getDBPool } from '../src/utils/db';
+import { IProductVat, IAccountSetting } from '../src/models/settings.model';
+
+let testAgent: request.SuperTest<request.Test>;
+let liveServer: Server;
+const pool = getDBPool(); // Get pool for cleanup tasks
+
+beforeAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    let attempts = 0;
+    const interval = setInterval(() => {
+      attempts++;
+      if (actualServerInstanceImport && actualServerInstanceImport.listening) {
+        clearInterval(interval);
+        liveServer = actualServerInstanceImport;
+        testAgent = request(liveServer);
+        console.log('Test suite connected to live server instance from server.ts for Settings Service.');
+        resolve();
+      } else if (attempts > 20) { // Approx 10 seconds timeout
+        clearInterval(interval);
+        console.error('Server instance from server.ts did not start in time for tests.');
+        reject(new Error('Server instance from server.ts did not start in time for tests.'));
+      }
+    }, 500);
+  });
+
+  // Initial cleanup of tables
+  try {
+    await pool.query('DELETE FROM products_vat;');
+    await pool.query('DELETE FROM account_settings;');
+    console.log('Initial cleanup of products_vat and account_settings tables done.');
+  } catch (error) {
+    console.warn('Initial cleanup failed, tables might not exist yet or other issue:', error);
+  }
+}, 15000);
+
+afterAll(async () => {
+  try {
+    await pool.query('DELETE FROM products_vat;');
+    await pool.query('DELETE FROM account_settings;');
+    console.log('Final cleanup of products_vat and account_settings tables done.');
+  } catch (error) {
+    console.error('Error during final cleanup:', error);
+  }
+  await endDBPool();
+  console.log('Test suite finished: DB Pool ended via test afterAll for Settings Service.');
+  if (liveServer && liveServer.listening) {
+    console.log('Note: Main server instance was not explicitly closed by test afterAll, relying on process shutdown for Settings Service.');
+  }
+});
+
+beforeEach(async () => {
+  // Clean tables before each test to ensure independence
+  try {
+    await pool.query('DELETE FROM products_vat;');
+    await pool.query('DELETE FROM account_settings;');
+  } catch (error) {
+    console.error('Error cleaning tables in beforeEach:', error);
+    // Depending on test strategy, might want to throw error to stop tests
+  }
+});
+
+
+describe('Settings Service API', () => {
+  describe('GET /', () => {
+    it('should return 200 OK with the correct service running message', async () => {
+      const response = await testAgent.get('/');
+      expect(response.status).toBe(200);
+      expect(response.text).toBe('Settings Service is running! (Phase 1)');
+    });
+  });
+
+  // --- ProductsVat API CRUD Tests ---
+  describe('ProductsVat API CRUD (/api/settings/products-vat)', () => {
+    const testProductVat1: IProductVat = {
+      productId: 'pv001',
+      ean: '1234567890123',
+      productName: 'Test Product VAT 1',
+      basePrice: 100.00,
+      vatRate: 21.00,
+      vatCategory: 'Standard',
+      countryCode: 'NL',
+      isCompound: false,
+      appliesToShipping: true,
+      createdDateTime: new Date(), // Will be set by DB or service
+      updatedDateTime: new Date(), // Will be set by DB or service
+      isActive: true,
+    };
+
+    const testProductVat2: IProductVat = {
+      productId: 'pv002',
+      ean: '9876543210987',
+      productName: 'Test Product VAT 2',
+      basePrice: 50.00,
+      vatRate: 9.00,
+      vatCategory: 'Reduced',
+      countryCode: 'DE',
+      createdDateTime: new Date(),
+      updatedDateTime: new Date(),
+      isActive: false,
+    };
+    let createdProductVatId: string;
+
+    it('POST /products-vat - should create a new product VAT entry', async () => {
+      const response = await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('productId', testProductVat1.productId);
+      expect(response.body.ean).toBe(testProductVat1.ean);
+      expect(response.body.productName).toBe(testProductVat1.productName);
+      expect(response.body.vatRate).toBe(testProductVat1.vatRate);
+      expect(response.body.countryCode).toBe(testProductVat1.countryCode);
+      createdProductVatId = response.body.productId;
+    });
+
+    it('POST /products-vat - should return 400 for missing required fields', async () => {
+      const { productId, ...incompleteData } = testProductVat1; // Removing productId
+      const response = await testAgent.post('/api/settings/products-vat').send(incompleteData);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Missing required fields');
+    });
+
+    it('GET /products-vat/:productId - should retrieve a specific product VAT entry', async () => {
+      // First, create an entry to retrieve
+      await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      const response = await testAgent.get(`/api/settings/products-vat/${testProductVat1.productId}`);
+      expect(response.status).toBe(200);
+      expect(response.body.productId).toBe(testProductVat1.productId);
+      expect(response.body.ean).toBe(testProductVat1.ean);
+    });
+
+    it('GET /products-vat/:productId - should return 404 for non-existent product VAT ID', async () => {
+      const response = await testAgent.get('/api/settings/products-vat/nonexistentpv99');
+      expect(response.status).toBe(404);
+    });
+
+    it('GET /products-vat - should retrieve all product VAT entries', async () => {
+      await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      await testAgent.post('/api/settings/products-vat').send(testProductVat2);
+      const response = await testAgent.get('/api/settings/products-vat');
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body.length).toBeGreaterThanOrEqual(2);
+      expect(response.body.some(pv => pv.productId === testProductVat1.productId)).toBe(true);
+      expect(response.body.some(pv => pv.productId === testProductVat2.productId)).toBe(true);
+    });
+
+    it('PUT /products-vat/:productId - should update an existing product VAT entry', async () => {
+      await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      const updatedData = { productName: 'Updated Product Name', vatRate: 25.00, isActive: false };
+      const response = await testAgent.put(`/api/settings/products-vat/${testProductVat1.productId}`).send(updatedData);
+      expect(response.status).toBe(200);
+      expect(response.body.productName).toBe('Updated Product Name');
+      expect(response.body.vatRate).toBe(25.00);
+      expect(response.body.isActive).toBe(false);
+      expect(new Date(response.body.updatedDateTime).getTime()).toBeGreaterThanOrEqual(new Date(testProductVat1.updatedDateTime).getTime());
+    });
+
+    it('PUT /products-vat/:productId - should return 404 for updating non-existent product VAT ID', async () => {
+      const response = await testAgent.put('/api/settings/products-vat/nonexistentpv99').send({ productName: 'No Such Product' });
+      expect(response.status).toBe(404);
+    });
+
+    it('PUT /products-vat/:productId - should return 400 if productId in body conflicts with path', async () => {
+      await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      const updatedData = { productId: 'conflictingID', productName: 'Conflicting Update' };
+      const response = await testAgent.put(`/api/settings/products-vat/${testProductVat1.productId}`).send(updatedData);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Product ID in body does not match ID in path');
+    });
+
+
+    it('DELETE /products-vat/:productId - should delete a product VAT entry', async () => {
+      await testAgent.post('/api/settings/products-vat').send(testProductVat1);
+      const response = await testAgent.delete(`/api/settings/products-vat/${testProductVat1.productId}`);
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('deleted successfully');
+
+      const getResponse = await testAgent.get(`/api/settings/products-vat/${testProductVat1.productId}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    it('DELETE /products-vat/:productId - should return 404 for deleting non-existent product VAT ID', async () => {
+      const response = await testAgent.delete('/api/settings/products-vat/nonexistentpv99');
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // --- AccountSettings API CRUD Tests ---
+  describe('AccountSettings API CRUD (/api/settings/account-settings)', () => {
+    const testAccountSetting1: IAccountSetting = {
+      accountId: 'acc001',
+      accountName: 'Test Account 1',
+      countryCode: 'NL',
+      currencyCode: 'EUR',
+      defaultFulfilmentMethod: 'FBB',
+      vatRegistrationNumber: 'NL123456789B01',
+      createdDateTime: new Date(),
+      updatedDateTime: new Date(),
+      isActive: true,
+    };
+
+    const testAccountSetting2: IAccountSetting = {
+      accountId: 'acc002',
+      accountName: 'Test Account 2',
+      countryCode: 'DE',
+      currencyCode: 'EUR',
+      isActive: false,
+      createdDateTime: new Date(),
+      updatedDateTime: new Date(),
+    };
+    let createdAccountSettingId: string;
+
+    it('POST /account-settings - should create a new account setting', async () => {
+      const response = await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('accountId', testAccountSetting1.accountId);
+      expect(response.body.accountName).toBe(testAccountSetting1.accountName);
+      expect(response.body.countryCode).toBe(testAccountSetting1.countryCode);
+      createdAccountSettingId = response.body.accountId;
+    });
+
+    it('POST /account-settings - should return 400 for missing required fields', async () => {
+      const { accountId, ...incompleteData } = testAccountSetting1; // Removing accountId
+      const response = await testAgent.post('/api/settings/account-settings').send(incompleteData);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Missing required fields');
+    });
+
+    it('GET /account-settings/:accountId - should retrieve a specific account setting', async () => {
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      const response = await testAgent.get(`/api/settings/account-settings/${testAccountSetting1.accountId}`);
+      expect(response.status).toBe(200);
+      expect(response.body.accountId).toBe(testAccountSetting1.accountId);
+      expect(response.body.accountName).toBe(testAccountSetting1.accountName);
+    });
+
+    it('GET /account-settings/:accountId - should return 404 for non-existent account ID', async () => {
+      const response = await testAgent.get('/api/settings/account-settings/nonexistentacc99');
+      expect(response.status).toBe(404);
+    });
+
+    it('GET /account-settings - should retrieve all account settings', async () => {
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting2);
+      const response = await testAgent.get('/api/settings/account-settings');
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body.length).toBeGreaterThanOrEqual(2);
+      expect(response.body.some(as => as.accountId === testAccountSetting1.accountId)).toBe(true);
+      expect(response.body.some(as => as.accountId === testAccountSetting2.accountId)).toBe(true);
+    });
+
+    it('PUT /account-settings/:accountId - should update an existing account setting', async () => {
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      const updatedData = { accountName: 'Updated Account Name', currencyCode: 'USD', isActive: false };
+      const response = await testAgent.put(`/api/settings/account-settings/${testAccountSetting1.accountId}`).send(updatedData);
+      expect(response.status).toBe(200);
+      expect(response.body.accountName).toBe('Updated Account Name');
+      expect(response.body.currencyCode).toBe('USD');
+      expect(response.body.isActive).toBe(false);
+      expect(new Date(response.body.updatedDateTime).getTime()).toBeGreaterThanOrEqual(new Date(testAccountSetting1.updatedDateTime).getTime());
+    });
+
+    it('PUT /account-settings/:accountId - should return 404 for updating non-existent account ID', async () => {
+      const response = await testAgent.put('/api/settings/account-settings/nonexistentacc99').send({ accountName: 'No Such Account' });
+      expect(response.status).toBe(404);
+    });
+
+    it('PUT /account-settings/:accountId - should return 400 if accountId in body conflicts with path', async () => {
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      const updatedData = { accountId: 'conflictingAccID', accountName: 'Conflicting Update' };
+      const response = await testAgent.put(`/api/settings/account-settings/${testAccountSetting1.accountId}`).send(updatedData);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Account ID in body does not match ID in path');
+    });
+
+    it('DELETE /account-settings/:accountId - should delete an account setting', async () => {
+      await testAgent.post('/api/settings/account-settings').send(testAccountSetting1);
+      const response = await testAgent.delete(`/api/settings/account-settings/${testAccountSetting1.accountId}`);
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('deleted successfully');
+
+      const getResponse = await testAgent.get(`/api/settings/account-settings/${testAccountSetting1.accountId}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    it('DELETE /account-settings/:accountId - should return 404 for deleting non-existent account ID', async () => {
+      const response = await testAgent.delete('/api/settings/account-settings/nonexistentacc99');
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/settings_service/tsconfig.json
+++ b/settings_service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/settings_service/vitest.config.ts
+++ b/settings_service/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [
+    tsconfigPaths(),
+  ],
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'c8',
+      reporter: ['text', 'json', 'html'],
+      reportsDirectory: './coverage',
+    },
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Duplicates the existing shop_service to create a new settings_service.

Includes:
- New table schemas and models for 'products_vat' and 'account_settings'.
- CRUD service functions for these entities.
- Corresponding controller handlers and API routes.
- New database migration for the new tables.
- Updated docker-compose.yml to include settings_service on port 3001 with its own database SettingsDb.
- Basic API tests for the new CRUD endpoints (build and execution of tests were skipped by user request).