### PR TITLE
refactor: Implement multi-step onboarding form UI and logic

### DIFF
--- a/frontend/remos-react/components/onboarding/BolApiForm.js
+++ b/frontend/remos-react/components/onboarding/BolApiForm.js
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { callApi } from '@/utils/api';
 
-export default function BolApiForm() {
+export default function BolApiForm({ onComplete }) { // Added onComplete prop
   const { markStepAsComplete, onboardingStatus } = useOnboarding();
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
@@ -27,7 +27,7 @@ export default function BolApiForm() {
 
       await markStepAsComplete('hasConfiguredBolApi');
       setSuccessMessage(prev => prev + 'Onboarding step updated.');
-
+      if (onComplete) onComplete(); // Call onComplete on success
     } catch (err) {
       console.error('Failed to configure Bol.com API:', err);
       const errorMessage = (err && err.message) ? err.message : String(err);

--- a/frontend/remos-react/components/onboarding/InvoiceSettingsForm.js
+++ b/frontend/remos-react/components/onboarding/InvoiceSettingsForm.js
@@ -13,7 +13,7 @@ const initialFormData = {
   nextInvoiceNumber: 1,
 };
 
-export default function InvoiceSettingsForm() {
+export default function InvoiceSettingsForm({ onComplete }) { // Added onComplete prop
   const { markStepAsComplete, onboardingStatus } = useOnboarding();
   const [formData, setFormData] = useState(initialFormData);
   const [isLoading, setIsLoading] = useState(false);
@@ -52,7 +52,7 @@ export default function InvoiceSettingsForm() {
 
       await markStepAsComplete('hasCompletedInvoiceSetup');
       setSuccessMessage(prev => prev + 'Onboarding step updated.');
-
+      if (onComplete) onComplete(); // Call onComplete on success
     } catch (err) {
       console.error('Failed to save invoice settings:', err);
       const errorMessage = (err && err.message) ? err.message : String(err);

--- a/frontend/remos-react/components/onboarding/ShopSync.js
+++ b/frontend/remos-react/components/onboarding/ShopSync.js
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { callApi } from '@/utils/api';
 
-export default function ShopSync() {
+export default function ShopSync({ onComplete }) { // Added onComplete prop
   const { markStepAsComplete, onboardingStatus } = useOnboarding();
   const [syncStatus, setSyncStatus] = useState({
     orders: '',
@@ -54,6 +54,7 @@ export default function ShopSync() {
     setError(null);
     try {
       await markStepAsComplete('hasCompletedShopSync');
+      if (onComplete) onComplete(); // Call onComplete on success
     } catch (err) {
       console.error('Failed to mark shop sync as complete:', err);
       const errorMessage = (err && err.message) ? err.message : String(err);

--- a/frontend/remos-react/components/onboarding/VatSetup.js
+++ b/frontend/remos-react/components/onboarding/VatSetup.js
@@ -6,7 +6,7 @@ import { useOnboarding } from '@/contexts/OnboardingContext';
 // For now, let's assume it works or we'll simplify the JSX if Layout isn't appropriate for this component context.
 // import Layout from "@/components/layout/Layout";
 
-export default function VatSetup() {
+export default function VatSetup({ onComplete }) { // Added onComplete prop
   const { markStepAsComplete, onboardingStatus } = useOnboarding();
 
   // State for this component
@@ -119,6 +119,7 @@ export default function VatSetup() {
     setStepCompletionError(null);
     try {
       await markStepAsComplete('hasCompletedVatSetup');
+      if (onComplete) onComplete(); // Call onComplete on success
       // Optionally re-fetch products or clear list if needed after step completion
     } catch (err) {
       console.error('Failed to mark VAT setup as complete:', err);


### PR DESCRIPTION
- I modified frontend/remos-react/app/onboarding/page.js to manage a currentStepIndex.
- The onboarding page now renders only one step component at a time.
- I added a visual StepperUI to show progress.
- Individual step components (BolApiForm, ShopSync, VatSetup, InvoiceSettingsForm) now accept and call an onComplete prop after successful step completion, which triggers navigation to the next step in the parent.
- I removed the generic 'Next' button from parent; step progression is driven by actions within each step component.
- I retained the 'Previous' button in parent for backward navigation.